### PR TITLE
Remove UTF-8 BOMs and clean up trailing whitespace

### DIFF
--- a/lib/puppet/provider/inittab/parsed.rb
+++ b/lib/puppet/provider/inittab/parsed.rb
@@ -1,4 +1,4 @@
-﻿require 'puppet/provider/parsedfile'
+require 'puppet/provider/parsedfile'
 inittab_file = '/etc/inittab'
 
 Puppet::Type.type(:inittab).provide(
@@ -7,9 +7,9 @@ Puppet::Type.type(:inittab).provide(
   :default_target => inittab_file,
   :filetype       => :flat
 ) do
-  
+
   confine :exists => inittab_file
-  
+
   text_line :comment, :match => /^\s*#/;
   text_line :blank, :match => /^\s*$/;
 
@@ -17,7 +17,7 @@ Puppet::Type.type(:inittab).provide(
   # Inittab[<name>]: Could not evaluate: Field 'runlevel' is required
   # http://groups.google.com/group/puppet-users/browse_thread/thread/1d6f3eebbc39aa99
   # -JDF 2011/11/22
-  record_line :parsed, 
+  record_line :parsed,
     :fields    => %w{name runlevel action command},
     :optional  => %w{runlevel action command},
     :joiner    => ":",

--- a/lib/puppet/type/inittab.rb
+++ b/lib/puppet/type/inittab.rb
@@ -1,4 +1,4 @@
-﻿Puppet::Type.newtype(:inittab) do
+Puppet::Type.newtype(:inittab) do
   @doc = "Management of inittab entries
   inittab { 'x':
     ensure   => present,


### PR DESCRIPTION
The BOMs (Byte Order Marks) at the beginning of Ruby files caused errors on Puppet 3.4.
